### PR TITLE
Use Tomologic python onbuild to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4.2-onbuild
+FROM tomologic/python:3-onbuild
 
 RUN apt-get update && \
     apt-get install -y jq && \


### PR DESCRIPTION
```
REPOSITORY            TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
tomologic/awscli      latest              2ad192f47e03        19 minutes ago      776.1 MB
tomologic/awscli      latest              6b7b99c1162a        52 seconds ago      416.6 MB
```
